### PR TITLE
Avoid output of 'Properties of the ...' when there are no properties; and add output for 'default' property of schema.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+
+[*.js]
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Auto detect text files and perform LF normalization
+* text=auto eol=lf
+
+*.js text
+*.json text
+*.md text

--- a/index.js
+++ b/index.js
@@ -59,10 +59,12 @@ function generateSchemaSectionText(octothorpes, name, isRequired, schema, subSch
 		schema.description
 	]
 	if (schemaType === 'object') {
-		text.push('Properties of the `' + name + '` object:')
-		generatePropertySection(octothorpes, schema, subSchemas).forEach(function(section) {
-			text = text.concat(section)
-		})
+		if (schema.properties) {
+			text.push('Properties of the `' + name + '` object:')
+			generatePropertySection(octothorpes, schema, subSchemas).forEach(function(section) {
+				text = text.concat(section)
+			})
+		}
 	} else if (schemaType === 'array') {
 		var itemsType = schema.items && schema.items.type
 		if (!itemsType && schema.items['$ref']) {
@@ -157,7 +159,9 @@ module.exports = function(schema) {
 			text.push('## `' + subSchemaTypeName + '` (' + schema.definitions[subSchemaTypeName].type + ')')
 			text.push(schema.definitions[subSchemaTypeName].description)
 			if (schema.definitions[subSchemaTypeName].type === 'object') {
-				text.push('Properties of the `' + subSchemaTypeName + '` object:')
+				if (schema.definitions[subSchemaTypeName].properties) {
+					text.push('Properties of the `' + subSchemaTypeName + '` object:')
+				}
 			}
 			generatePropertySection('##', schema.definitions[subSchemaTypeName], subSchemaTypes).forEach(function(section) {
 				text = text.concat(section)

--- a/index.js
+++ b/index.js
@@ -89,6 +89,15 @@ function generateSchemaSectionText(octothorpes, name, isRequired, schema, subSch
 		}).join('\n'))
 	}
 
+	if (schema.default !== undefined) {
+		if (schema.default === null || [ "boolean", "number", "string" ].indexOf(typeof schema.default) !== -1) {
+			text.push('Default: `' + JSON.stringify(schema.default) + '`')
+		} else {
+			text.push('Default:')
+			text.push('```\n' + JSON.stringify(schema.default, null, 2) + '\n```')
+		}
+	}
+
 	var restrictions = generatePropertyRestrictions(schema)
 	if (restrictions) {
 		text.push('Additional restrictions:')

--- a/test/markdown/default-properties.md
+++ b/test/markdown/default-properties.md
@@ -1,0 +1,57 @@
+# Example Schema
+
+This schema is awesome.
+
+The schema defines the following properties:
+
+## `price` (number)
+
+Cost of the product.
+
+Default: `0`
+
+## `color` (string)
+
+Color of the product.
+
+Default: `"red"`
+
+## `elasticated` (boolean)
+
+Indicates whether the garments are elasticated.
+
+Default: `true`
+
+## `availableStyles` (array)
+
+Lists of the available styles of the product.
+
+The object is an array with all elements of the type `string`.
+
+Default:
+
+```
+[
+  "plain",
+  "stripes",
+  "stars"
+]
+```
+
+## `washingRecommendation` (object)
+
+Washing recommendations.
+
+Default:
+
+```
+{
+  "temperature": "Wash at or below 60°C"
+}
+```
+
+## `specialOffer` (object)
+
+An associated special offer.
+
+Default: `null`

--- a/test/markdown/simple-no-properties.md
+++ b/test/markdown/simple-no-properties.md
@@ -1,0 +1,23 @@
+# Example Schema
+
+This schema is awesome.
+
+The schema defines the following properties:
+
+## `custom` (customProperties)
+
+Custom configuration properties.
+
+## `paths` (object)
+
+Named paths.
+
+---
+
+# Sub Schemas
+
+The schema defines the following additional types:
+
+## `customProperties` (object)
+
+Map of custom configuration properties.

--- a/test/schemas/default-properties.json
+++ b/test/schemas/default-properties.json
@@ -1,0 +1,41 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Example Schema",
+	"description": "This schema is awesome.",
+	"type": "object",
+	"properties": {
+		"price": {
+			"description": "Cost of the product.",
+			"type": "number",
+			"default": 0
+		},
+		"color": {
+			"description": "Color of the product.",
+			"type": "string",
+			"default": "red"
+		},
+		"elasticated": {
+			"description": "Indicates whether the garments are elasticated.",
+			"type": "boolean",
+			"default": true
+		},
+		"availableStyles": {
+			"description": "Lists of the available styles of the product.",
+			"type": "array",
+			"items": { "type": "string" },
+			"default": [ "plain", "stripes", "stars" ]
+		},
+		"washingRecommendation": {
+			"description": "Washing recommendations.",
+			"type": "object",
+			"default": {
+				"temperature": "Wash at or below 60°C"
+			}
+		},
+		"specialOffer": {
+			"description": "An associated special offer.",
+			"type": "object",
+			"default": null
+		}
+	}
+}

--- a/test/schemas/simple-no-properties.json
+++ b/test/schemas/simple-no-properties.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Example Schema",
+	"description": "This schema is awesome.",
+	"type": "object",
+	"properties": {
+		"custom": {
+			"description": "Custom configuration properties.",
+			"$ref": "#/definitions/customProperties"
+		},
+		"paths": {
+			"description": "Named paths.",
+			"type": "object",
+			"additionalProperties": { "type": "string" }
+		}
+	},
+	"definitions": {
+		"customProperties": {
+			"description": "Map of custom configuration properties.",
+			"type": "object"
+		}
+	}
+}

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,7 @@ var testGoodFiles = [
 	'simple-deep',
 	'simple-no-title',
 	'simple-definition',
+	'simple-no-properties',
 	'one-of',
 	'examples'
 ]

--- a/test/test.js
+++ b/test/test.js
@@ -13,7 +13,8 @@ var testGoodFiles = [
 	'simple-definition',
 	'simple-no-properties',
 	'one-of',
-	'examples'
+	'examples',
+	"default-properties"
 ]
 
 test('All the files parse as expected.', function(t) {

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,7 @@ test('All the files parse as expected.', function(t) {
 		var json = require('./schemas/' + file + '.json')
 		var markdown = fs.readFileSync('./test/markdown/' + file + '.md', 'utf8')
 		var parsed = parser(json)
-		t.equal(parsed, markdown, 'markdown file should match parser output')
+		t.equal(parsed, markdown, 'markdown file "' + file + '" should match parser output')
 	})
 	t.end()
 })


### PR DESCRIPTION
I have also added:

- `.editorconfig` for formatting consistency since the editors that I use have different defaults for whitespace.
-  `.gitattributes` so that unit tests pass on Windows (CRLF line-endings caused tests to fail).