### PR TITLE
Support "primitive" schemas, with better enum support

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ module.exports = function(schema) {
 		generatePropertySection(octothorpes, schema, subSchemaTypes).forEach(function(section) {
 			text = text.concat(section)
 		})
-	} else if (schema.type === 'array') {
+	} else {
 		text = text.concat(generateSchemaSectionText('#' + octothorpes, undefined, false, schema, subSchemaTypes));
 	}
 

--- a/index.js
+++ b/index.js
@@ -76,11 +76,32 @@ function generateSchemaSectionText(octothorpes, name, isRequired, schema, subSch
 		if (!itemsType && schema.items['$ref']) {
 			itemsType = getActualType(schema.items, subSchemas)
 		}
-		if(name) {
+		if(itemsType && name) {
 			text.push('The object is an array with all elements of the type `' + itemsType + '`.')
 		}
-		else {
+		else if (itemsType) {
 			text.push('The schema defines an array with all elements of the type `' + itemsType + '`.')
+		}
+		else {
+			var validationItems = []
+			if (schema.items.allOf) {
+				text.push('The elements of the array must match *all* of the following properties:')
+				validationItems = schema.items.allOf
+			} else if (schema.items.anyOf) {
+				text.push('The elements of the array must match *at least one* of the following properties:')
+				validationItems = schema.items.anyOf
+			} else if (schema.items.oneOf) {
+				text.push('The elements of the array must match *exactly one* of the following properties:')
+				validationItems = schema.items.oneOf
+			} else if (schema.items.not) {
+				text.push('The elements of the array must *not* match the following properties:')
+				validationItems = schema.items.not
+			}
+			if (validationItems.length > 0) {
+				validationItems.forEach(function(item) {
+					text = text.concat(generateSchemaSectionText(octothorpes, undefined, false, item, subSchemas))
+				})
+			}
 		}
 		if (itemsType === 'object') {
 			text.push('The array object has the following properties:')

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ function getActualType(schema, subSchemas) {
 	}
 }
 
-module.exports = function(schema) {
+module.exports = function(schema, startOcto) {
 	var subSchemaTypes = Object.keys(schema.definitions || {}).reduce(function(map, subSchemaTypeName) {
 		map['#/definitions/' + subSchemaTypeName] = subSchemaTypeName
 		return map
@@ -152,6 +152,9 @@ module.exports = function(schema) {
 
 	var text = []
 	var octothorpes = ''
+	if(startOcto) {
+		octothorpes = startOcto;
+	}
 
 	if (schema.title) {
 		octothorpes += '#'

--- a/index.js
+++ b/index.js
@@ -11,7 +11,10 @@ var coreSchemaTypes = [
 ]
 
 function generateElementTitle(octothorpes, elementName, elementType, isRequired, example) {
-	var text = [ octothorpes, ' `', elementName, '`' ]
+	var text = [ octothorpes ]
+	if(elementName) {
+		text.push(' `' + elementName + '`');
+	}
 	if (elementType || isRequired) {
 		text.push(' (')
 		if (elementType) {
@@ -70,7 +73,12 @@ function generateSchemaSectionText(octothorpes, name, isRequired, schema, subSch
 		if (!itemsType && schema.items['$ref']) {
 			itemsType = getActualType(schema.items, subSchemas)
 		}
-		text.push('The object is an array with all elements of the type `' + itemsType + '`.')
+		if(name) {
+			text.push('The object is an array with all elements of the type `' + itemsType + '`.')
+		}
+		else {
+			text.push('The schema defines an array with all elements of the type `' + itemsType + '`.')
+		}
 		if (itemsType === 'object') {
 			text.push('The array object has the following properties:')
 			generatePropertySection(octothorpes, schema.items, subSchemas).forEach(function(section) {
@@ -149,16 +157,18 @@ module.exports = function(schema) {
 		octothorpes += '#'
 		text.push(octothorpes + ' ' + schema.title)
 	}
-	if (schema.description) {
-		text.push(schema.description)
-	}
 
 	if (schema.type === 'object') {
+		if (schema.description) {
+			text.push(schema.description)
+		}
 		text.push('The schema defines the following properties:')
 		generatePropertySection(octothorpes, schema, subSchemaTypes).forEach(function(section) {
 			text = text.concat(section)
 		})
-	} else if (schema.type === 'array') {}
+	} else if (schema.type === 'array') {
+		text = text.concat(generateSchemaSectionText('#' + octothorpes, undefined, false, schema, subSchemaTypes));
+	}
 
 	if (schema.definitions) {
 		text.push('---')

--- a/test/markdown/bare-array.md
+++ b/test/markdown/bare-array.md
@@ -1,0 +1,7 @@
+# Example Schema
+
+## (array)
+
+This schema is awesome.
+
+The schema defines an array with all elements of the type `string`.

--- a/test/markdown/bare-boolean.md
+++ b/test/markdown/bare-boolean.md
@@ -1,0 +1,5 @@
+# Example Schema
+
+## (boolean)
+
+This schema is awesome.

--- a/test/markdown/bare-integer.md
+++ b/test/markdown/bare-integer.md
@@ -1,0 +1,5 @@
+# Example Schema
+
+## (integer)
+
+This schema is awesome.

--- a/test/markdown/bare-null.md
+++ b/test/markdown/bare-null.md
@@ -1,0 +1,5 @@
+# Example Schema
+
+## (null)
+
+This schema is awesome.

--- a/test/markdown/bare-number.md
+++ b/test/markdown/bare-number.md
@@ -1,0 +1,5 @@
+# Example Schema
+
+## (number)
+
+This schema is awesome.

--- a/test/markdown/bare-string-enum.md
+++ b/test/markdown/bare-string-enum.md
@@ -1,0 +1,12 @@
+# Example Schema
+
+## (string, enum)
+
+This schema is awesome.
+
+This element must be one of the following enum values:
+
+* `great`
+* `strings`
+* `think`
+* `alike`

--- a/test/markdown/bare-string.md
+++ b/test/markdown/bare-string.md
@@ -1,0 +1,5 @@
+# Example Schema
+
+## (string)
+
+This schema is awesome.

--- a/test/markdown/examples.md
+++ b/test/markdown/examples.md
@@ -20,11 +20,11 @@ Some pants.
 
 Properties of the `pants` object:
 
-### `color` (enum, required)
+### `color` (string, enum, required)
 
 The color of pants.
 
-The object is an enum, with one of the following required values:
+This element must be one of the following enum values:
 
 * `red`
 * `white`

--- a/test/markdown/items-one-of.md
+++ b/test/markdown/items-one-of.md
@@ -1,0 +1,15 @@
+# Example Schema
+
+This schema is awesome.
+
+The schema defines the following properties:
+
+## `numbersOrStrings` (array)
+
+A flexible limited list
+
+The elements of the array must match *exactly one* of the following properties:
+
+## (number)
+
+## (string)

--- a/test/markdown/simple-definition.md
+++ b/test/markdown/simple-definition.md
@@ -20,11 +20,11 @@ Some pants.
 
 Properties of the `pants` object:
 
-### `color` (enum, required)
+### `color` (string, enum, required)
 
 The color of pants.
 
-The object is an enum, with one of the following required values:
+This element must be one of the following enum values:
 
 * `red`
 * `white`

--- a/test/markdown/simple-enum.md
+++ b/test/markdown/simple-enum.md
@@ -4,11 +4,11 @@ This schema is awesome.
 
 The schema defines the following properties:
 
-## `butts` (enum)
+## `butts` (string, enum)
 
 The kind of butts.
 
-The object is an enum, with one of the following required values:
+This element must be one of the following enum values:
 
 * `big`
 * `small`

--- a/test/schemas/bare-array.json
+++ b/test/schemas/bare-array.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Example Schema",
+	"description": "This schema is awesome.",
+	"type": "array",
+	"items": {
+		"type": "string"
+	}
+}

--- a/test/schemas/bare-boolean.json
+++ b/test/schemas/bare-boolean.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Example Schema",
+	"description": "This schema is awesome.",
+	"type": "boolean"
+}

--- a/test/schemas/bare-integer.json
+++ b/test/schemas/bare-integer.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Example Schema",
+	"description": "This schema is awesome.",
+	"type": "integer"
+}

--- a/test/schemas/bare-null.json
+++ b/test/schemas/bare-null.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Example Schema",
+	"description": "This schema is awesome.",
+	"type": "null"
+}

--- a/test/schemas/bare-number.json
+++ b/test/schemas/bare-number.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Example Schema",
+	"description": "This schema is awesome.",
+	"type": "number"
+}

--- a/test/schemas/bare-string-enum.json
+++ b/test/schemas/bare-string-enum.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Example Schema",
+	"description": "This schema is awesome.",
+	"type": "string",
+	"enum": [
+		"great",
+		"strings",
+		"think",
+		"alike"
+	]
+}

--- a/test/schemas/bare-string.json
+++ b/test/schemas/bare-string.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Example Schema",
+	"description": "This schema is awesome.",
+	"type": "string"
+}

--- a/test/schemas/examples.json
+++ b/test/schemas/examples.json
@@ -16,6 +16,7 @@
 			"properties": {
 				"color": {
 					"description": "The color of pants.",
+					"type": "string",
 					"enum": ["red", "white", "blue"]
 				},
 				"size": {

--- a/test/schemas/items-one-of.json
+++ b/test/schemas/items-one-of.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Example Schema",
+	"description": "This schema is awesome.",
+	"type": "object",
+	"properties": {
+		"numbersOrStrings" :{
+			"description": "A flexible limited list",
+			"type": "array",
+			"items": {
+				"oneOf": [
+					{ "type": "number" },
+					{ "type": "string" }
+				]
+			}
+		}
+	}
+}

--- a/test/schemas/simple-definition.json
+++ b/test/schemas/simple-definition.json
@@ -16,6 +16,7 @@
 			"properties": {
 				"color": {
 					"description": "The color of pants.",
+					"type": "string",
 					"enum": ["red", "white", "blue"]
 				},
 				"size": {

--- a/test/schemas/simple-enum.json
+++ b/test/schemas/simple-enum.json
@@ -6,6 +6,7 @@
 	"properties": {
 		"butts": {
 			"description": "The kind of butts.",
+			"type": "string",
 			"enum": ["big", "small", 9001]
 		}
 	}

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,11 @@ var testGoodFiles = [
 	'simple-definition',
 	'simple-no-properties',
 	'bare-array',
+	'bare-boolean',
+	'bare-integer',
+	'bare-null',
+	'bare-number',
+	'bare-string',
 	'one-of',
 	'examples',
 	"default-properties"

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,7 @@ var testGoodFiles = [
 	'bare-string',
 	'bare-string-enum',
 	'one-of',
+	'items-one-of',
 	'examples',
 	"default-properties"
 ]

--- a/test/test.js
+++ b/test/test.js
@@ -18,6 +18,7 @@ var testGoodFiles = [
 	'bare-null',
 	'bare-number',
 	'bare-string',
+	'bare-string-enum',
 	'one-of',
 	'examples',
 	"default-properties"

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,7 @@ var testGoodFiles = [
 	'simple-no-title',
 	'simple-definition',
 	'simple-no-properties',
+	'bare-array',
 	'one-of',
 	'examples',
 	"default-properties"


### PR DESCRIPTION
Sorry for a Pull Request that does two things, but they are tied together.

1. Support primitive schemas (example in `test/schemas/bare-integer.json`)
2. Support `enum` as a validation rather than a type

I'm working with this for an API documentation tool and will likely add some more commits soon.
Let me know if you prefer to separate functionalities across PRs.

Cheers.